### PR TITLE
Fix Borderless Fullscreen sometimes not applying on game startup

### DIFF
--- a/GraphicsSettings/GraphicsSettings.cs
+++ b/GraphicsSettings/GraphicsSettings.cs
@@ -50,6 +50,12 @@ namespace GraphicsSettings
         private UnityEngine.Object configManager;
         private bool configManagerSearch = false;
 
+        private void Start()
+        {
+            if(DisplayMode.Value == SettingEnum.DisplayMode.BorderlessFullscreen)
+                StartCoroutine(RemoveBorder());
+        }
+
         private void Awake()
         {
             Resolution = Config.Bind(CATEGORY_RENDER, "Resolution", "", new ConfigDescription(DESCRIPTION_RESOLUTION, null, new ConfigurationManagerAttributes { Order = 9, HideDefaultButton = true, CustomDrawer = new Action<ConfigEntryBase>(ResolutionDrawer) }));
@@ -61,9 +67,6 @@ namespace GraphicsSettings
             AnisotropicFiltering = Config.Bind(CATEGORY_RENDER, "Anisotropic filtering", SettingEnum.AnisotropicFilteringMode.Default, new ConfigDescription(DESCRIPTION_ANISOFILTER));
             RunInBackground = Config.Bind(CATEGORY_GENERAL, "Run in background", SettingEnum.RunInBackgroundMode.Default, new ConfigDescription(DESCRIPTION_RUNINBACKGROUND));
             OptimizeInBackground = Config.Bind(CATEGORY_GENERAL, "Optimize in background", true, new ConfigDescription(DESCRIPTION_OPTIMIZEINBACKGROUND));
-
-            if(DisplayMode.Value == SettingEnum.DisplayMode.BorderlessFullscreen)
-                StartCoroutine(RemoveBorder());
 
             DisplayMode.SettingChanged += (sender, args) => SetDisplayMode();
             SelectedMonitor.SettingChanged += (sender, args) => StartCoroutine(SelectMonitor());


### PR DESCRIPTION
## Fix: Borderless Fullscreen Not Applying on Game Startup

### Problem
The borderless fullscreen display mode was not being applied correctly when the game starts in fullscreen mode. Users had to manually switch between fullscreen and borderless fullscreen in the settings to make it work properly.

### Root Cause
The original implementation was calling `RemoveBorder()` in the `Awake()` method, which executes very early in Unity's initialization lifecycle. At this point, the game's display system may not be fully initialized, causing the borderless fullscreen modifications to be ineffective or overridden by subsequent game initialization.

### Solution
Moved the borderless fullscreen initialization logic from the `Awake()` method to the `Start()` method.

**Key Changes:**
- Removed borderless fullscreen logic from `Awake()` method (line ~65)
- Added borderless fullscreen logic to `Start()` method
- `Start()` executes later in Unity's lifecycle, after the display system is properly initialized

### Technical Details
- **Before**: `Awake()` → Configuration binding + immediate borderless fullscreen application
- **After**: `Awake()` → Configuration binding only, `Start()` → borderless fullscreen application

This change leverages Unity's execution order where `Start()` is called after all `Awake()` calls have completed and the scene is fully loaded, ensuring the display system is ready for window manipulation.

### Testing
- Verified that borderless fullscreen mode now applies correctly on game startup without requiring manual intervention
- Confirmed that manual switching between display modes still works as expected
- No impact on other graphics settings functionality

### Impact
- **Fixes**: Borderless fullscreen not applying on startup
- **Improves**: User experience by eliminating the need for manual display mode cycling
- **Maintains**: All existing functionality for display mode switching