### PR TITLE
Improve Resolution config entry, use it to override resolution

### DIFF
--- a/GraphicsSettings/GraphicsSettings.cs
+++ b/GraphicsSettings/GraphicsSettings.cs
@@ -153,7 +153,7 @@ namespace GraphicsSettings
                 Resolution.BoxedValue = "";
             }
 
-                GUILayout.Space(5);
+            GUILayout.Space(5);
             if(GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
             {
                 var display = Display.displays[SelectedMonitor.Value];

--- a/GraphicsSettings/GraphicsSettings.cs
+++ b/GraphicsSettings/GraphicsSettings.cs
@@ -43,6 +43,8 @@ namespace GraphicsSettings
 
         private string resolutionX = Screen.width.ToString();
         private string resolutionY = Screen.height.ToString();
+        private int origResolutionX = Screen.width;
+        private int origResolutionY = Screen.height;
         private bool framerateToggle = false;
         private WinAPI.WindowStyleFlags backupStandard;
         private WinAPI.WindowStyleFlags backupExtended;
@@ -132,8 +134,8 @@ namespace GraphicsSettings
             if(GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
             {
                 var display = Display.displays[SelectedMonitor.Value];
-                if(Screen.width != display.systemWidth || Screen.height != display.systemHeight)
-                    StartCoroutine(SetResolution(display.systemWidth, display.systemHeight));
+                if(Screen.width != origResolutionX || Screen.height != origResolutionY)
+                    StartCoroutine(SetResolution(origResolutionX, origResolutionY));
             }
 
             IEnumerator SetResolution(int width, int height)


### PR DESCRIPTION
I encountered a game where it would always load at 1080x1920 regardless of changes made via this plugin in previous sessions. Modifying the plugin felt like the easiest path forward to force it up to 4k.

These changes affect the behavior of the Resolution settings in the following ways:
1. The "Reset" button now resets to the Resolution used at load time. I found it using the full dimensions of the current monitor unintuitive.
2. The dummy Resolution setting in the config is no longer a dummy and, if set, will be used at load time to change the resolution. 
3. Any subsequent changes to the resolution will be mirrored to the config file but IFF the Resolution was already set in the config file

Regarding #3, I went this route instead of always using the value so I could maintain previous functionality and not change how the plugin works in every use case, thereby limiting - if not eliminating - unintended consequences of the change. If maintainers would prefer to always use it, I welcome the edits.